### PR TITLE
DT-1437 ignore errors that cannot be recovered

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   owasp: entur/owasp@0.0.10
-  hmpps: ministryofjustice/hmpps@1.1.1
+  hmpps: ministryofjustice/hmpps@2.2
 
 executors:
   validator:
@@ -58,6 +58,8 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
+          context:
+            - hmpps-common-vars
           filters:
             branches:
               only:
@@ -73,7 +75,9 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
-          context: case-notes-to-probation-preprod
+          context:
+            - case-notes-to-probation-preprod
+            - hmpps-common-vars
           requires:
             - request-preprod-approval
       - request-prod-approval:
@@ -84,7 +88,9 @@ workflows:
           name: deploy_prod
           env: "prod"
           slack_notification: true
-          context: case-notes-to-probation-prod
+          context:
+            - case-notes-to-probation-prod
+            - hmpps-common-vars
           requires:
             - request-prod-approval
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "2.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "2.1.2"
   kotlin("plugin.spring") version "1.4.21"
 }
 
@@ -30,7 +30,7 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
   implementation("org.springframework:spring-jms")
-  implementation(platform("com.amazonaws:aws-java-sdk-bom:1.11.918"))
+  implementation(platform("com.amazonaws:aws-java-sdk-bom:1.11.931"))
   implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.0.8")
 
   testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusher.kt
@@ -29,12 +29,11 @@ class CaseNoteListenerPusher(
     }
 
     val caseNote = caseNotesService.getCaseNote(offenderIdDisplay, caseNoteId)
-    if (caseNote.text.isEmpty()) {
-      log.warn("Ignoring case note id for message with id {} and type {} because case note text is empty", MessageId, eventType)
+    if (caseNote.isInvalid(MessageId, eventType)) {
       return
     }
 
-    with(caseNote) {
+    with(caseNote!!) {
       log.debug(
         "Found case note {} of type {} {} in case notes service, now pushing to delius with event id {}",
         caseNoteId,
@@ -49,6 +48,28 @@ class CaseNoteListenerPusher(
       )
     }
     deliusService.postCaseNote(DeliusCaseNote(caseNote))
+  }
+
+  private fun CaseNote?.isInvalid(messageId: String, eventType: String): Boolean {
+    if (this == null) {
+      log.warn(
+        "Ignoring case note id for message with id {} and type {} because we could not find the case note",
+        messageId,
+        eventType
+      )
+      return true
+    }
+
+    if (this.text.isEmpty()) {
+      log.warn(
+        "Ignoring case note id for message with id {} and type {} because case note text is empty",
+        messageId,
+        eventType
+      )
+      return true
+    }
+
+    return false
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusher.kt
@@ -25,14 +25,30 @@ class CaseNoteListenerPusher(
 
     if (caseNoteId.isNullOrEmpty()) {
       log.warn("Ignoring null case note id for message with id {} and type {}", MessageId, eventType)
-    } else {
-      val caseNote = caseNotesService.getCaseNote(offenderIdDisplay, caseNoteId)
-      with(caseNote) {
-        log.debug("Found case note {} of type {} {} in case notes service, now pushing to delius with event id {}", caseNoteId, type, subType, eventId)
-        telemetryClient.trackEvent("CaseNoteCreate", mapOf("caseNoteId" to caseNoteId, "type" to "$type-$subType", "eventId" to eventId.toString()), null)
-      }
-      deliusService.postCaseNote(DeliusCaseNote(caseNote))
+      return
     }
+
+    val caseNote = caseNotesService.getCaseNote(offenderIdDisplay, caseNoteId)
+    if (caseNote.text.isEmpty()) {
+      log.warn("Ignoring case note id for message with id {} and type {} because case note text is empty", MessageId, eventType)
+      return
+    }
+
+    with(caseNote) {
+      log.debug(
+        "Found case note {} of type {} {} in case notes service, now pushing to delius with event id {}",
+        caseNoteId,
+        type,
+        subType,
+        eventId
+      )
+      telemetryClient.trackEvent(
+        "CaseNoteCreate",
+        mapOf("caseNoteId" to caseNoteId, "type" to "$type-$subType", "eventId" to eventId.toString()),
+        null
+      )
+    }
+    deliusService.postCaseNote(DeliusCaseNote(caseNote))
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusher.kt
@@ -29,9 +29,7 @@ class CaseNoteListenerPusher(
     }
 
     val caseNote = caseNotesService.getCaseNote(offenderIdDisplay, caseNoteId)
-    if (caseNote.isInvalid(MessageId, eventType)) {
-      return
-    }
+    if (caseNote.isInvalid(MessageId, eventType)) return
 
     with(caseNote!!) {
       log.debug(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNotesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNotesService.kt
@@ -3,15 +3,19 @@ package uk.gov.justice.digital.hmpps.pollpush.services
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.security.oauth2.client.OAuth2RestTemplate
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Service
 open class CaseNotesService(@Qualifier("caseNotesApiRestTemplate") private val restTemplate: OAuth2RestTemplate) {
-  open fun getCaseNote(offenderId: String, caseNoteId: String): CaseNote {
-    val response = restTemplate.getForEntity("/case-notes/{offenderId}/{caseNoteId}", CaseNote::class.java, offenderId, caseNoteId)
-    return response.body!!
-  }
+  open fun getCaseNote(offenderId: String, caseNoteId: String): CaseNote? =
+    try {
+      val response = restTemplate.getForEntity("/case-notes/{offenderId}/{caseNoteId}", CaseNote::class.java, offenderId, caseNoteId)
+      response.body
+    } catch(ex: HttpClientErrorException.NotFound) {
+      null
+    }
 }
 
 data class CaseNote(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNotesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNotesService.kt
@@ -13,7 +13,7 @@ class CaseNotesService(@Qualifier("caseNotesApiRestTemplate") private val restTe
     try {
       val response = restTemplate.getForEntity("/case-notes/{offenderId}/{caseNoteId}", CaseNote::class.java, offenderId, caseNoteId)
       response.body
-    } catch(ex: HttpClientErrorException.NotFound) {
+    } catch (ex: HttpClientErrorException.NotFound) {
       null
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNotesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNotesService.kt
@@ -8,8 +8,8 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Service
-open class CaseNotesService(@Qualifier("caseNotesApiRestTemplate") private val restTemplate: OAuth2RestTemplate) {
-  open fun getCaseNote(offenderId: String, caseNoteId: String): CaseNote? =
+class CaseNotesService(@Qualifier("caseNotesApiRestTemplate") private val restTemplate: OAuth2RestTemplate) {
+  fun getCaseNote(offenderId: String, caseNoteId: String): CaseNote? =
     try {
       val response = restTemplate.getForEntity("/case-notes/{offenderId}/{caseNoteId}", CaseNote::class.java, offenderId, caseNoteId)
       response.body

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusherIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusherIntTest.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.pollpush.services
 
 import com.amazonaws.services.sqs.AmazonSQS
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.exactly
+import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.put
 import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
@@ -13,6 +15,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.client.HttpServerErrorException
+import uk.gov.justice.digital.hmpps.pollpush.services.CaseNotesExtension.Companion.caseNotesApi
 import uk.gov.justice.digital.hmpps.pollpush.services.DeliusExtension.Companion.communityApi
 import uk.gov.justice.digital.hmpps.pollpush.services.health.IntegrationTest
 
@@ -31,12 +34,12 @@ class CaseNoteListenerPusherIntTest : IntegrationTest() {
   @Qualifier("awsSqsDlqClient")
   private lateinit var awsSqsDlqClient: AmazonSQS
 
-  private val validCaseNoteEvent =
+  private fun validCaseNoteEvent(offenderIdDisplay: String = "G4803UT") =
     """{
     "MessageId": "ae06c49e-1f41-4b9f-b2f2-dcca610d02cd", "Type": "Notification", "Timestamp": "2019-10-21T14:01:18.500Z", 
     "Message": 
       "{\"eventId\":\"5958295\",\"eventType\":\"KA-KE\",\"eventDatetime\":\"2019-10-21T15:00:25.489964\",
-      \"rootOffenderId\":2419065,\"offenderIdDisplay\":\"G4803UT\",\"agencyLocationId\":\"MDI\", \"caseNoteId\": 1234}", 
+      \"rootOffenderId\":2419065,\"offenderIdDisplay\":\"$offenderIdDisplay\",\"agencyLocationId\":\"MDI\", \"caseNoteId\": 1234}", 
     "TopicArn": "arn:aws:sns:eu-west-1:000000000000:offender_events", 
     "MessageAttributes": {"eventType": {"Type": "String", "Value": "KA-KE"}, 
     "id": {"Type": "String", "Value": "8b07cbd9-0820-0a0f-c32f-a9429b618e0b"}, 
@@ -51,7 +54,7 @@ class CaseNoteListenerPusherIntTest : IntegrationTest() {
         .willReturn(aResponse().withStatus(404))
     )
 
-    pusher.pushCaseNoteToDelius(validCaseNoteEvent)
+    pusher.pushCaseNoteToDelius(validCaseNoteEvent())
 
     communityApi.verify(putRequestedFor(urlPathEqualTo("/secure/nomisCaseNotes/A1234AF/-25")))
   }
@@ -63,7 +66,24 @@ class CaseNoteListenerPusherIntTest : IntegrationTest() {
         .willReturn(aResponse().withStatus(503))
     )
 
-    assertThatThrownBy { pusher.pushCaseNoteToDelius(validCaseNoteEvent) }
+    assertThatThrownBy { pusher.pushCaseNoteToDelius(validCaseNoteEvent()) }
       .isInstanceOf(HttpServerErrorException.ServiceUnavailable::class.java)
   }
+
+  @Test
+  fun `case note not found does not throw an exception or call delius`() {
+    caseNotesApi.stubFor(
+      get(urlMatching("/case-notes/N4803NF/1234"))
+        .willReturn(
+          aResponse().withHeader("Content-type", "application/json")
+            .withStatus(404)
+            .withBody("{\"status\":\"404\",\"developerMessage\":\"case note not found\"}")
+        )
+    )
+
+    pusher.pushCaseNoteToDelius(validCaseNoteEvent("N4803NF"))
+
+    communityApi.verify(exactly(0), putRequestedFor(urlMatching("/secure/nomisCaseNotes/.*")))
+  }
+
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusherIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusherIntTest.kt
@@ -85,5 +85,4 @@ class CaseNoteListenerPusherIntTest : IntegrationTest() {
 
     communityApi.verify(exactly(0), putRequestedFor(urlMatching("/secure/nomisCaseNotes/.*")))
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusherTest.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.pollpush.services
 
 import com.google.gson.GsonBuilder
 import com.microsoft.applicationinsights.TelemetryClient
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.doNothing
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
@@ -86,7 +88,14 @@ class CaseNoteListenerPusherTest {
     verify(caseNotesService, never()).getCaseNote(anyString(), anyString())
   }
 
-  private fun createCaseNote() = CaseNote(
+  @Test
+  fun `delius service not called if case note has empty text`() {
+    whenever(caseNotesService.getCaseNote(anyString(), anyString())).thenReturn(createCaseNote(text = ""))
+    pusher.pushCaseNoteToDelius(validCaseNoteEvent)
+    verify(deliusService, never()).postCaseNote(any())
+  }
+
+  private fun createCaseNote(text: String = "note content") = CaseNote(
     eventId = 123456,
     offenderIdentifier = "offenderId",
     type = "NEG",
@@ -94,7 +103,7 @@ class CaseNoteListenerPusherTest {
     creationDateTime = LocalDateTime.parse("2019-04-16T11:22:33"),
     occurrenceDateTime = LocalDateTime.parse("2019-03-23T11:22:00"),
     authorName = "Some Name",
-    text = "note content",
+    text = text,
     locationId = "LEI",
     amendments = listOf()
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pollpush/services/CaseNoteListenerPusherTest.kt
@@ -4,7 +4,6 @@ import com.google.gson.GsonBuilder
 import com.microsoft.applicationinsights.TelemetryClient
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.check
-import com.nhaarman.mockitokotlin2.doNothing
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock


### PR DESCRIPTION
Delius cannot handle case notes with empty text - ignore.
If the case note or offender are no longer in the system - ignore.